### PR TITLE
Add sentinel to consumer loop when there are no more results to consume

### DIFF
--- a/solr2es/__main__.py
+++ b/solr2es/__main__.py
@@ -150,6 +150,8 @@ class Solr2EsAsync(object):
         while results:
             try:
                 results = await queue.pop()
+                if results == []:
+                    break
                 actions = create_es_actions(index_name, results, translation_map)
                 await self.aes.bulk(actions, index_name, DEFAULT_ES_DOC_TYPE, refresh=self.refresh)
                 nb_results += len(results)


### PR DESCRIPTION
I have added a change to the resume function.  When I was testing solr2es for some migrations, I was getting  the error message listed below.  This is my attempt to fix that.  
I apologize if I am going about this the wrong way.  Please advise me on any tips for contributing using the proper methods in the future.

2019-03-14 18:57:51,063 [solr2es][99] ERROR: exception while reading results []
  Traceback (most recent call last):
     File "/usr/local/lib/python3.7/site-packages/solr2es/__main__.py", line 159, in resume
       await self.aes.bulk(actions, index_name, DEFAULT_ES_DOC_TYPE, refresh=self.refresh)
     File "/usr/local/lib/python3.7/site-packages/elasticsearch/client/utils.py", line 76, in _wrapped
       return func(*args, params=params, **kwargs)
     File "/usr/local/lib/python3.7/site-packages/elasticsearch/client/__init__.py", line 1152, in bulk
      raise ValueError("Empty value passed for a required argument 'body'.")
  ValueError: Empty value passed for a required argument 'body'.